### PR TITLE
Doc: masternodelist replaced with listmasternodes

### DIFF
--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -77,7 +77,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
             "  start-alias  - Start single masternode by assigned alias configured in masternode.conf\n"
             "  start-<mode> - Start masternodes configured in masternode.conf (<mode>: 'all', 'missing', 'disabled')\n"
             "  status       - Print masternode status information\n"
-            "  list         - Print list of all known masternodes (see masternodelist for more info)\n"
+            "  list         - Print list of all known masternodes (see listmasternodes for more info)\n"
             "  list-conf    - Print masternode.conf in JSON format\n"
             "  winners      - Print list of masternode winners\n");
 


### PR DESCRIPTION
Doc: replaced 'masternodelist' with 'listmasternodes' in the usage message